### PR TITLE
0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning].
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 <!-- Versions -->
-[unreleased]: https://github.com/Author/Repository/compare/v0.0.2...HEAD
-[0.0.2]: https://github.com/Author/Repository/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/Author/Repository/releases/tag/v0.0.1
+[0.6.0]: https://github.com/aafrecct/funalone/releases/tag/0.6.0
+[0.5.1]: https://github.com/aafrecct/funalone/releases/tag/0.5.1
+[0.5.0]: https://github.com/aafrecct/funalone/releases/tag/0.5.0
+[0.4.0]: https://github.com/aafrecct/funalone/releases/tag/0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog],
+and this project adheres to [Semantic Versioning].
+
+
+## [0.6.0] - 2025-01-14
+- Breaking
+
+### Added
+- New `DefaultMockingContext` now has the functionality of old `MockCollection` and `IsolatedContext`, removing the extra unnecessary depth.
+
+### Changed
+- Context manager renamed to `IsolatedFunctionClone`
+- Context manager is now a callable that will act as the isolated function.
+- The custom `globals` context of the cloned function can now be accessed though the `context` attribute of `IsolatedFunctionClone`.
+- Type hints
+
+### Removed
+- Intermediary object `MockCollection`. (Replaced, see 'Added')
+- Intermediary object `IsolatedContext`. (Replaced, see 'Added')
+
+
+## [0.5.1] - 2024-10-30
+
+### Added
+- Defaults can now be striped from the cloned function.
+- Added some documentation. (Much missing still)
+
+### Fixed
+- Fixed missing import.
+- Minor fixes.
+
+
+## [0.5.0] - 2024-10-30
+
+### Added
+- Functions can now keep original globals and only override certain ones.
+- Functions can now keep default arguments.
+- Kept globals can be specified with a list of strings.
+- Mocks can now be created and modified like attributes in the collection.
+
+### Changed
+- Refactored functionality into two files.
+- Reworked how mocks are created and stored.
+
+### Fixed
+- Minor fixes
+
+
+## [0.4.0] - 2024-10-17
+
+### Changed
+- Changed from a function decorator to a context manager for versatility.
+- Made dependency logging optional
+
+
+## [0.0.1] - 2024-09-27
+
+- initial release
+
+
+<!------------------------------------->
+
+<!-- Links -->
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html
+
+<!-- Versions -->
+[unreleased]: https://github.com/Author/Repository/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/Author/Repository/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/Author/Repository/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -1,27 +1,46 @@
 # FunAlone
 
-A small python library that makes it easy to test a function alone, that is, mocking all
+A small python library that makes it easy to test a **fun**ction **alone**, that is, mocking all
 dependencies. True unittests, without having to manually look and add every called function to an
 increasing list of @mock.patch decorators.
 
-## Changelog
+## Example
 
-### 0.5.1
-- Defaults can now be striped from the cloned function.
-- Added some documentation. (Much missing still)
-- Fixed missing import.
-- Minor fixes.
+Say you have a function named `do_a_lot_of_stuff` and you want to test it with `unittest`, only testing the functions code, not the function that it calls within.
 
-### 0.5.0
-- Separated functionality into two different files.
-- Functions can now keep original globals and only override certain ones.
-- Functions can now keep default arguments.
-- Kept globals can be specified with a list of strings.
-- Reworked how mocks are created and stored.
-- Mocks can now be created and modified like attributes in the collection.
-- Minor fixes
+```python
+def do_a_lot_of_stuff(arg: int):
+    if arg > 5:
+        result = do_this(arg)
+    elif arg < 0:
+        result = do_that(arg)
+    else:
+        result = do_nothing(arg)
+    
+    return result
+```
 
-### 0.4.0
-- Changed from a function decorator to a context manager for versatility.
-- Made dependency logging optional
+In this case you might want to know which external function has been called, depending on the input, without having the code actually call that function (which could have side effects and should have it's own unit tests).
+
+```python
+class Test(unittest.TestCase):
+    def test_do_a_lot_of_stuff_with_5(self):
+        with IsolatedFunctionClone(
+            do_a_lot_of_stuff
+            ) as do_a_lot_of_stuff:
+
+            # This calls a function clone with an isolated context.
+            # All external names are mocked.
+            do_a_lot_of_stuff(5)
+
+            # You can access this context later to assert calls,
+            # And you can use the original functions to do this,
+            # so it's all refactor-friendly.
+            do_a_lot_of_stuff.context[do_this].assert_not_called()
+            do_a_lot_of_stuff.context[do_that].assert_not_called()
+            do_a_lot_of_stuff.context[do_nothing].assert_called_once()
+
+```
+
+There are more parameters and ways to use the library, this is only a basic example.
 

--- a/funalone/__init__.py
+++ b/funalone/__init__.py
@@ -1,8 +1,8 @@
-from .mock_context import IsolatedContext, IsolatedContextManager
+from .mock_context import IsolatedFunctionClone, DefaultMockingContext
 from .namespaced_function import create_namespaced_function_clone
 
 __all__ = [
     "create_namespaced_function_clone",
-    "IsolatedContext",
-    "IsolatedContextManager",
+    "IsolatedFunctionClone",
+    "DefaultMockingContext",
 ]

--- a/funalone/mock_context.py
+++ b/funalone/mock_context.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from sys import stderr
 from types import FunctionType
-from typing import Any, Iterable
+from typing import Any, Iterable, Protocol
 from unittest.mock import MagicMock, Mock
 
 from funalone.namespaced_function import create_namespaced_function_clone
@@ -14,17 +14,18 @@ from funalone.namespaced_function import create_namespaced_function_clone
 BUILTIN_NAMES = dir(builtins)
 
 
-class IsolatedContextManager(ContextDecorator):
+class NamedObject(Protocol):
+    def __name__(self) -> str: ...
+
+
+class IsolatedFunctionClone(ContextDecorator):
     """A context manager that creates a namespaced clone of a function with
     access to a dummy `globals` object that creates mocks on the fly or serves
     custom ones for the missing external dependencies, while keeping track of
     statistics like access counts.
 
     Attributes:
-        original_function: A reference to the original function.
-        isolated_function: The cloned function with overwriten globals.
-            Can also be accesed as an attrribute with the name of the original
-            function if it doesn't clash for readability.
+        original_function: A reference to the original function..
         context: A reference to the `globals` context of the isolated function.
         mocked_objects: A shortcut reference to the `MockCollection` used by the
             context. Same as `self.context.mocked_objects`.
@@ -37,53 +38,98 @@ class IsolatedContextManager(ContextDecorator):
         mock_builtins: bool = False,
         log_dependency_access_count: bool = False,
         alert_on_default_mock: bool = False,
-        custom_mocked_objects: dict | Iterable[tuple[object, Mock]] | None = None,
-        name_allow_list: Iterable[object] | bool = False,
+        custom_mocked_objects: dict | Iterable[tuple[NamedObject, Mock]] | None = None,
+        name_allow_list: Iterable[NamedObject] | bool = False,
         strip_function_defaults: bool = False,
         **kw_custom_mocked_objects,
     ):
-        global_context = IsolatedContext(
-            mock_builtins,
+        self.context = DefaultMockingContext(
             custom_mocked_objects,
+            mock_builtins,
             **kw_custom_mocked_objects,
         )
-
-        self.original_function = tested_function
         self._namespaced_function_clone = create_namespaced_function_clone(
             tested_function,
-            global_context,
+            self.context,
             keep_original_globals=_process_name_allow_list(name_allow_list),
             strip_original_defaults=strip_function_defaults,
         )
-
-        def exec_isolated_function(*args, **kwargs):
-            self.context.start()
-            return self._namespaced_function_clone(*args, **kwargs)
-
-        self.isolated_function = exec_isolated_function
-
-        if tested_function.__name__ not in self.__dict__:
-            setattr(self, tested_function.__name__, exec_isolated_function)
-
-        self.context = global_context
-        self.mocked_objects = self.context.mocked_objects
+        self.original_function = tested_function
         self.log_dependency_access_count = log_dependency_access_count
         self.alert_on_default_mock = alert_on_default_mock
+
+    def __call__(self, *args, **kwargs):
+        self.activate()
+        result = self._namespaced_function_clone(*args, **kwargs)
+        self.deactivate()
+        return result
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
         if self.log_dependency_access_count:
-            print(self.context.dependency_access_count_str(), file=stderr)
+            print(self.dependency_access_count_message(), file=stderr)
 
         if self.alert_on_default_mock:
-            print(self.context.default_mock_alert_str(), file=stderr)
+            print(self.default_mock_alert_message(), file=stderr)
 
-        self.context.end()
+        self.deactivate()
+
+    def activate(self):
+        self.context.set_state(ContextStates.ACTIVE)
+
+    def deactivate(self):
+        self.context.set_state(ContextStates.ENDED)
+
+    def dependency_access_count_message(self) -> str:
+        accessct_str = "\n\t".join(
+            f"{name}: {mock_item.metadata.active_access_count}"
+            for name, mock_item in self.context.items()
+        )
+        if not accessct_str.strip():
+            accessct_str = "<No external dependencies>"
+        return f"Dependency access count: \n\t{accessct_str}"
+
+    def default_mock_alert_message(self) -> str:
+        default_mocks = [
+            name
+            for name, mock_item in self.context.items()
+            if not mock_item.metadata.is_custom
+        ]
+        return "\n".join(
+            f"`{key}` is not properly mocked and uses a default Mock."
+            for key in default_mocks
+        )
 
 
-class IsolatedContext(dict):
+@dataclass
+class MockMetadata:
+    """A dataclass to track the metadata of a MockItem"""
+
+    is_custom: bool
+    total_access_count: int
+    active_access_count: int
+
+
+@dataclass
+class MockItem:
+    """A pair used by DefaultMockingContext to keep custom mocks along with
+    metadata for them."""
+
+    object: Any
+    metadata: MockMetadata
+
+
+class ContextStates(Enum):
+    """The posible states in which a DefaultMockingContext might be."""
+
+    SETUP = 0
+    ACTIVE = 1
+    ENDED = 2
+
+
+class DefaultMockingContext(dict):
     """A dict-like object that creates MagicMocks on not-found key lookups.
 
     A collection of key value pairs that returns a new named MagicMock object when
@@ -92,93 +138,36 @@ class IsolatedContext(dict):
     debugging and allows specification of custom Mock objects for certain keys.
 
     Attributes:
-        mocked_objects: An instance of MockCollection that stores Mocks and their
-            metadata. It allows creation of mocks on attribute or item access for
-            ease of configuration.
+        mock_builtins: Whether the context mocks builtin names automatically or
+            keeps default builtins.
     """
 
     def __init__(
         self,
+        custom_mocked_objects: dict | Iterable[tuple[NamedObject, Mock]] | None = None,
         mock_builtins: bool = False,
-        custom_mocked_objects: dict | Iterable[tuple[object, Mock]] | None = None,
         **kw_custom_mocked_objects,
-    ) -> None:
+    ):
+        object.__setattr__(self, "state", ContextStates.SETUP)
+        object.__setattr__(self, "mock_builtins", mock_builtins)
+
         custom_mocked_objects = _process_custom_mocks(
             custom_mocked_objects, **kw_custom_mocked_objects
         )
+        mocks = {
+            k: MockItem(v, MockMetadata(True, 0, 0))
+            for k, v in custom_mocked_objects.items()
+        }
 
-        self.mocked_objects = MockCollection(custom_mocked_objects)
-        self.mock_builtins = mock_builtins
-
-    def __getitem__(self, item: str):
-        if not self.mock_builtins and item in BUILTIN_NAMES:
-            return getattr(builtins, item)
-
-        return self.mocked_objects._get_mock(item)
-
-    def __str__(self) -> str:
-        return str(self.mocked_objects)
-
-    def setdefault(self, key, value) -> None:
-        self.mocked_objects.setdefault(key, value)
-
-    def dependency_access_count_str(self) -> str:
-        accessct_str = "\n\t".join(
-            f"{name}: {mock_item.metadata.active_access_count}"
-            for name, mock_item in self.mocked_objects.items()
-        )
-        if not accessct_str.strip():
-            accessct_str = "<No external dependencies>"
-        return "Dependency access count: \n" f"\t{accessct_str}"
-
-    def default_mock_alert_str(self) -> str:
-        default_mocks = [
-            name
-            for name, mock_item in self.mocked_objects.items()
-            if not mock_item.metadata.is_custom
-        ]
-        return "\n".join(
-            f"`{key}` is not properly mocked and uses a default Mock."
-            for key in default_mocks
-        )
-
-    def start(self):
-        self.mocked_objects.set_state(ContextStates.ACTIVE)
-
-    def end(self):
-        self.mocked_objects.set_state(ContextStates.ENDED)
-
-
-@dataclass
-class MockMetadata:
-    is_custom: bool
-    total_access_count: int
-    active_access_count: int
-
-
-@dataclass
-class MockItem:
-    object: Mock
-    metadata: MockMetadata
-
-
-class ContextStates(Enum):
-    SETUP = 0
-    ACTIVE = 1
-    ENDED = 2
-
-
-class MockCollection(dict):
-    def __init__(self, init: dict | None = None):
-        object.__setattr__(self, "state", ContextStates.SETUP)
-        mocks = (
-            {k: MockItem(v, MockMetadata(True, 0, 0)) for k, v in init.items()}
-            if init
-            else {}
-        )
         super(__class__, self).__init__(mocks)
 
-    def _get_mock(self, name: str) -> Any:
+    def _get_mock(self, name: str | NamedObject) -> Any:
+        if not isinstance(name, str):
+            name = name.__name__
+
+        if not self.mock_builtins and name in BUILTIN_NAMES:
+            return getattr(builtins, name)
+
         active_access = 1 if self.state == ContextStates.ACTIVE else 0
         if result := super(__class__, self).get(name):
             result.metadata.total_access_count += 1
@@ -191,12 +180,18 @@ class MockCollection(dict):
         )
         return result
 
-    def _set_mock(self, name: str, value: Any) -> None:
+    def _set_mock(self, name: str | NamedObject, value: Any) -> None:
+        if not isinstance(name, str):
+            name = name.__name__
+
         super(__class__, self).__setitem__(
             name, MockItem(value, MockMetadata(True, 1, 0))
         )
 
-    def setdefault(self, name, value) -> None:
+    def setdefault(self, name: str | NamedObject, value: Any) -> None:
+        if not isinstance(name, str):
+            name = name.__name__
+
         if super(__class__, self).get(name) is not None:
             return
         self._set_mock(name, value)
@@ -217,7 +212,7 @@ class MockCollection(dict):
 
 def _process_custom_mocks(
     custom_mocked_objects: dict[str, Mock]
-    | Iterable[tuple[object, Mock]]
+    | Iterable[tuple[NamedObject, Mock]]
     | None = None,
     **kw_custom_mocked_objects,
 ) -> dict[str, Mock]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funalone"
-version = "0.5.1"
+version = "0.6.0"
 description = "Unittest functions isolated."
 authors = ["Borja Martinena"]
 license = "MIT"


### PR DESCRIPTION
# [0.6.0]
- Breaking

## Added
- New `DefaultMockingContext` now has the functionality of old `MockCollection` and `IsolatedContext`, removing the extra unnecessary depth.

## Changed
- Context manager renamed to `IsolatedFunctionClone`
- Context manager is now a callable that will act as the isolated function.
- The custom `globals` context of the cloned function can now be accessed though the `context` attribute of `IsolatedFunctionClone`.
- Type hints

## Removed
- Intermediary object `MockCollection`. (Replaced, see 'Added')
- Intermediary object `IsolatedContext`. (Replaced, see 'Added')