### PR TITLE
Support cloning functions that reassign their module globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [0.7.4]
+
+### Fixed
+- Functions that reassign one of their own module-level globals (`global x; x = ...`) can now
+  be cloned and executed. CPython's `STORE_GLOBAL` writes the raw value straight into the
+  globals dict (bypassing `__setitem__`), so reading the name back used to raise
+  `AttributeError: 'str' object has no attribute 'metadata'`. The context now adopts such raw
+  values into a `MockItem` on read, tagged with the new `MockOrigin.REASSIGNED_GLOBAL` origin,
+  and `reset()` tolerates raw values that were never read back.
+
+### Added
+- New `MockOrigin.REASSIGNED_GLOBAL` origin for values written into the context by the tested
+  function itself via `STORE_GLOBAL`.
+
 ## [0.7.1] - 2025-05-30
 
 ### Changed
@@ -99,6 +113,7 @@ type signature.
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 <!-- Versions -->
+[0.7.4]: https://github.com/aafrecct/funalone/releases/tag/0.7.4
 [0.7.1]: https://github.com/aafrecct/funalone/releases/tag/0.7.1
 [0.7.0]: https://github.com/aafrecct/funalone/releases/tag/0.7.0
 [0.6.0]: https://github.com/aafrecct/funalone/releases/tag/0.6.0

--- a/funalone/default_mocking_context.py
+++ b/funalone/default_mocking_context.py
@@ -17,6 +17,7 @@ from funalone.types import (
 )
 
 BUILTIN_NAMES = dir(builtins)
+_MISSING = object()
 
 
 class ContextStates(Enum):
@@ -88,7 +89,19 @@ class DefaultMockingContext(dict):
                 return builtin
 
         active_access = 1 if self.state == ContextStates.ACTIVE else 0
-        if result := super().get(name):
+        result = super().get(name, _MISSING)
+        if result is not _MISSING:
+            if not isinstance(result, MockItem):
+                # The value was written straight into the dict, bypassing
+                # `__setitem__`. This happens when a cloned function reassigns
+                # one of its module-level globals (`global x; x = ...`), since
+                # CPython's STORE_GLOBAL uses the C dict API. Adopt the raw
+                # value into a MockItem so access tracking stays consistent and
+                # reading it back does not fail.
+                result = MockItem(
+                    result, MockMetadata(MockOrigin.REASSIGNED_GLOBAL, 0, 0)
+                )
+                super().__setitem__(name, result)
             result.metadata.total_access_count += 1
             result.metadata.active_access_count += active_access
             return result.object
@@ -135,6 +148,10 @@ class DefaultMockingContext(dict):
 
     def reset(self):
         for mock_item in self.values():
+            if not isinstance(mock_item, MockItem):
+                # Raw value written via STORE_GLOBAL that was never read back
+                # and therefore never adopted into a MockItem.
+                continue
             mock_item.metadata.total_access_count = 0
             mock_item.metadata.active_access_count = 0
             if isinstance(mock_item.object, Mock):

--- a/funalone/types.py
+++ b/funalone/types.py
@@ -18,6 +18,7 @@ class MockOrigin(Enum):
     FUNCTION_ORIGINAL = 2
     GENERATED_WHILE_ACTIVE = 3
     GENERATED_WHILE_INACTIVE = 4
+    REASSIGNED_GLOBAL = 5
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funalone"
-version = "0.7.3"
+version = "0.7.4"
 description = "Unittest functions isolated."
 authors = ["Borja Martinena"]
 license = "MIT"

--- a/test/test_default_mocking_context.py
+++ b/test/test_default_mocking_context.py
@@ -60,6 +60,23 @@ class DefaultMockingContestTests(DeclarativeTestCase, TestCase):
             },
         },
         {
+            "message": "Reading a raw value written via STORE_GLOBAL adopts it",
+            "config": {
+                "allow_builtins": True,
+            },
+            "actions": [
+                lambda context: dict.__setitem__(
+                    context, "ext_variable", ext_variable
+                ),
+                lambda context: context["ext_variable"],
+            ],
+            "checks": {
+                "result": {
+                    "ext_variable": MI(ANY, MM(MO.REASSIGNED_GLOBAL, 1, 0)),
+                },
+            },
+        },
+        {
             "message": "Setting a value in the context",
             "config": {
                 "allow_builtins": True,

--- a/test/test_isolated_function_clone.py
+++ b/test/test_isolated_function_clone.py
@@ -18,6 +18,7 @@ from test.utils import (
     if_else_function,
     raise_and_catch_a_value_error,
     raise_and_catch_custom_exception,
+    reassign_and_read_module_global,
     return_external_variable,
     use_of_a_strange_object,
     use_of_str_builtin_function,
@@ -49,6 +50,14 @@ class IsolatedFunctionCloneTests(DeclarativeTestCase, TestCase):
             "args": (1, 2),
             "checks": {
                 "not_called": [check_one],
+            },
+        },
+        {
+            "message": "Reassigning and reading back a module-level global",
+            "function": reassign_and_read_module_global,
+            "args": ("reassigned",),
+            "checks": {
+                "result": "reassigned",
             },
         },
         {

--- a/test/utils.py
+++ b/test/utils.py
@@ -24,6 +24,19 @@ def return_external_variable() -> None:
     return ext_variable
 
 
+reassigned_module_global = "initial"
+
+
+def reassign_and_read_module_global(new_value: Any) -> Any:
+    """Example function.
+    Reassigns a module-level global and then reads it back within the same
+    call. This exercises a STORE_GLOBAL followed by a LOAD_GLOBAL of the same
+    name, which writes a raw (non-MockItem) value into the mocking context."""
+    global reassigned_module_global
+    reassigned_module_global = new_value
+    return reassigned_module_global
+
+
 def basic_two_int_function(a: int, b: int) -> int:
     """Example function.
     You can check if this fucntion has been called by checking the mock


### PR DESCRIPTION
A cloned function that reassigns one of its own module-level globals (`global x; x = ...`) could not be executed: CPython's STORE_GLOBAL writes the raw value straight into the globals dict via the C dict API, bypassing DefaultMockingContext.__setitem__, so the value is not wrapped in a MockItem. Reading the name back then raised `AttributeError: 'str' object has no attribute 'metadata'`.

The context now adopts raw (non-MockItem) values into a MockItem on read, tagged with a new MockOrigin.REASSIGNED_GLOBAL origin, and reset() tolerates raw values that were never read back. Using a sentinel for the presence check also fixes a latent bug where a stored falsy value would be treated as absent.